### PR TITLE
refactor: Clean up prime code and consume bytes method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wyrand"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "A fast & portable non-cryptographic pseudorandom number generator and hashing algorithm"

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -81,9 +81,9 @@ impl WyHash {
 
         match length {
             4..=16 => {
-                lo = (read_4_bytes(bytes) << 32) | read_4_bytes(&bytes[((length >> 3) << 2)..]);
-                hi = (read_4_bytes(&bytes[(length - 4)..]) << 32)
-                    | read_4_bytes(&bytes[(length - 4 - ((length >> 3) << 2))..]);
+                lo = (read_4_bytes(bytes) << 32) | read_4_bytes(&bytes[(length >> 3) << 2..]);
+                hi = (read_4_bytes(&bytes[length - 4..]) << 32)
+                    | read_4_bytes(&bytes[length - 4 - ((length >> 3) << 2)..]);
             }
             1..=3 => {
                 lo = read_upto_3_bytes(bytes);
@@ -130,8 +130,8 @@ impl WyHash {
                     start += 16
                 }
 
-                lo = read_8_bytes(&bytes[(length - 16)..]);
-                hi = read_8_bytes(&bytes[(length - 8)..]);
+                lo = read_8_bytes(&bytes[length - 16..]);
+                hi = read_8_bytes(&bytes[length - 8..]);
             }
         }
 

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -8,6 +8,7 @@ mod secret;
 use core::hash::Hasher;
 
 #[cfg(feature = "randomised_wyhash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "randomised_wyhash")))]
 pub use builder::RandomWyHashState;
 
 #[cfg(feature = "debug")]
@@ -19,7 +20,7 @@ use crate::{
 };
 
 use self::{
-    read::{is_over_48_bytes, wyread32, wyread64, wyread_upto_24},
+    read::{is_over_48_bytes, read_4_bytes, read_8_bytes, read_upto_3_bytes},
     secret::make_secret,
 };
 
@@ -73,19 +74,19 @@ impl WyHash {
     }
 
     #[inline]
-    fn consume_bytes(&mut self, bytes: &[u8]) {
+    fn consume_bytes(&self, bytes: &[u8]) -> (u64, u64, u64) {
         let (lo, hi): (u64, u64);
         let length = bytes.len();
         let mut seed = self.seed;
 
         match length {
             4..=16 => {
-                lo = (wyread32(bytes) << 32) | wyread32(&bytes[((length >> 3) << 2)..]);
-                hi = (wyread32(&bytes[(length - 4)..]) << 32)
-                    | wyread32(&bytes[(length - 4 - ((length >> 3) << 2))..]);
+                lo = (read_4_bytes(bytes) << 32) | read_4_bytes(&bytes[((length >> 3) << 2)..]);
+                hi = (read_4_bytes(&bytes[(length - 4)..]) << 32)
+                    | read_4_bytes(&bytes[(length - 4 - ((length >> 3) << 2))..]);
             }
             1..=3 => {
-                lo = wyread_upto_24(bytes);
+                lo = read_upto_3_bytes(bytes);
                 hi = 0;
             }
             0 => {
@@ -95,46 +96,46 @@ impl WyHash {
             _ => {
                 let mut index = length;
                 let mut start = 0;
+
                 if is_over_48_bytes(length) {
                     let mut seed1 = seed;
                     let mut seed2 = seed;
+
                     while is_over_48_bytes(index) {
                         seed = wymix(
-                            wyread64(&bytes[start..]) ^ self.secret[1],
-                            wyread64(&bytes[start + 8..]) ^ seed,
+                            read_8_bytes(&bytes[start..]) ^ self.secret[1],
+                            read_8_bytes(&bytes[start + 8..]) ^ seed,
                         );
                         seed1 = wymix(
-                            wyread64(&bytes[start + 16..]) ^ self.secret[2],
-                            wyread64(&bytes[start + 24..]) ^ seed1,
+                            read_8_bytes(&bytes[start + 16..]) ^ self.secret[2],
+                            read_8_bytes(&bytes[start + 24..]) ^ seed1,
                         );
                         seed2 = wymix(
-                            wyread64(&bytes[start + 32..]) ^ self.secret[3],
-                            wyread64(&bytes[start + 40..]) ^ seed2,
+                            read_8_bytes(&bytes[start + 32..]) ^ self.secret[3],
+                            read_8_bytes(&bytes[start + 40..]) ^ seed2,
                         );
                         index -= 48;
                         start += 48;
                     }
+
                     seed ^= seed1 ^ seed2;
                 }
 
                 while index > 16 {
                     seed = wymix(
-                        wyread64(&bytes[start..]) ^ self.secret[1],
-                        wyread64(&bytes[start + 8..]) ^ seed,
+                        read_8_bytes(&bytes[start..]) ^ self.secret[1],
+                        read_8_bytes(&bytes[start + 8..]) ^ seed,
                     );
                     index -= 16;
                     start += 16
                 }
 
-                lo = wyread64(&bytes[(length - 16)..]);
-                hi = wyread64(&bytes[(length - 8)..]);
+                lo = read_8_bytes(&bytes[(length - 16)..]);
+                hi = read_8_bytes(&bytes[(length - 8)..]);
             }
         }
 
-        self.lo = lo;
-        self.hi = hi;
-        self.seed = seed;
-        self.size += length as u64;
+        (lo, hi, seed)
     }
 }
 
@@ -142,7 +143,12 @@ impl Hasher for WyHash {
     #[inline]
     fn write(&mut self, bytes: &[u8]) {
         for chunk in bytes.chunks(u64::MAX as usize) {
-            self.consume_bytes(chunk);
+            let (lo, hi, seed) = self.consume_bytes(chunk);
+
+            self.lo = lo;
+            self.hi = hi;
+            self.seed = seed;
+            self.size += chunk.len() as u64;
         }
     }
 

--- a/src/hasher/primes.rs
+++ b/src/hasher/primes.rs
@@ -2,95 +2,50 @@
 ///
 /// Decompose into sum of powers of 2 (mod m)
 #[inline]
-const fn mul_mod(mut a: u64, mut b: u64, m: u64) -> u64 {
-    let mut r: u64 = 0;
-
-    while b > 0 {
-        if b & 1 == 1 {
-            let mut r2 = r.wrapping_add(a);
-            if r2 < r {
-                r2 = r2.wrapping_sub(m);
-            }
-            r = r2 % m;
-        }
-        b >>= 1;
-        if b > 0 {
-            let mut a2 = a.wrapping_add(a);
-            if a2 < a {
-                a2 = a2.wrapping_sub(m);
-            }
-            a = a2 % m;
-        }
-    }
-
-    r
+const fn mul_mod(a: u64, b: u64, modulo: u64) -> u64 {
+    ((a as u128 * b as u128) % modulo as u128) as u64
 }
 
 /// Calculate a^b (mod m)
 ///
 /// Decomposes into product of squares (mod m)
 #[inline]
-const fn pow_mod(mut a: u64, mut b: u64, m: u64) -> u64 {
-    let mut r: u64 = 1;
+const fn pow_mod(mut base: u64, mut exponent: u64, modulo: u64) -> u64 {
+    let mut result: u64 = 1;
 
-    while b > 0 {
-        if b & 1 == 1 {
-            r = mul_mod(r, a, m);
+    while exponent > 0 {
+        if exponent & 1 == 1 {
+            result = mul_mod(result, base, modulo);
         }
-        b >>= 1;
-        if b > 0 {
-            a = mul_mod(a, a, m);
+        exponent >>= 1;
+        if exponent > 0 {
+            base = mul_mod(base, base, modulo);
         }
     }
 
-    r
+    result
 }
 
 /// Strong Probable Primality test of the number `n` to the base `a`
 #[inline]
-const fn sprp(n: u64, a: u64) -> bool {
-    let mut d = n - 1;
-    let mut s: u8 = 0;
+const fn primality_test(n: u64, witness: u64, mut d: u64) -> bool {
+    let mut b = pow_mod(witness, d, n);
+    let n_minus = n - 1;
 
-    while (d & 0xff) == 0 {
-        d >>= 8;
-        s += 8;
-    }
-
-    if (d & 0xf) == 0 {
-        d >>= 4;
-        s += 4;
-    }
-
-    if (d & 0x3) == 0 {
-        d >>= 2;
-        s += 2;
-    }
-
-    if (d & 0x1) == 0 {
-        d >>= 1;
-        s += 1;
-    }
-
-    let mut b = pow_mod(a, d, n);
-
-    if b == 1 || b == (n - 1) {
+    if b == 1 || b == n_minus {
         return true;
     }
 
-    let mut r: u8 = 1;
-
-    while r < s {
+    while d != n_minus {
         b = mul_mod(b, b, n);
+        d *= 2;
 
         if b <= 1 {
             return false;
         }
-        if b == (n - 1) {
+        if b == n_minus {
             return true;
         }
-
-        r += 1;
     }
 
     false
@@ -113,19 +68,24 @@ pub(super) const fn is_prime(n: u64) -> bool {
         return false;
     }
 
-    sprp(n, 2)
+    let mut d = n - 1;
+    while d % 2 == 0 {
+        d >>= 1; // Same as dividing by two
+    }
+
+    primality_test(n, 2, d)
         || n < 2047
-        || sprp(n, 3)
-        || sprp(n, 5)
-        || sprp(n, 7)
-        || sprp(n, 11)
-        || sprp(n, 13)
-        || sprp(n, 17)
-        || sprp(n, 19)
-        || sprp(n, 23)
-        || sprp(n, 29)
-        || sprp(n, 31)
-        || sprp(n, 37)
+        || primality_test(n, 3, d)
+        || primality_test(n, 5, d)
+        || primality_test(n, 7, d)
+        || primality_test(n, 11, d)
+        || primality_test(n, 13, d)
+        || primality_test(n, 17, d)
+        || primality_test(n, 19, d)
+        || primality_test(n, 23, d)
+        || primality_test(n, 29, d)
+        || primality_test(n, 31, d)
+        || primality_test(n, 37, d)
 }
 
 #[cfg(test)]

--- a/src/hasher/read.rs
+++ b/src/hasher/read.rs
@@ -1,5 +1,5 @@
 #[inline(always)]
-pub(super) const fn wyread64(bits: &[u8]) -> u64 {
+pub(super) const fn read_8_bytes(bits: &[u8]) -> u64 {
     (bits[7] as u64) << 56
         | (bits[6] as u64) << 48
         | (bits[5] as u64) << 40
@@ -11,12 +11,12 @@ pub(super) const fn wyread64(bits: &[u8]) -> u64 {
 }
 
 #[inline(always)]
-pub(super) const fn wyread32(bits: &[u8]) -> u64 {
+pub(super) const fn read_4_bytes(bits: &[u8]) -> u64 {
     (bits[3] as u64) << 24 | (bits[2] as u64) << 16 | (bits[1] as u64) << 8 | (bits[0] as u64)
 }
 
 #[inline(always)]
-pub(super) const fn wyread_upto_24(bits: &[u8]) -> u64 {
+pub(super) const fn read_upto_3_bytes(bits: &[u8]) -> u64 {
     (bits[0] as u64) << 16 | (bits[bits.len() >> 1] as u64) << 8 | (bits[bits.len() - 1] as u64)
 }
 


### PR DESCRIPTION
Make some of the internal code more rusty, and otherwise try to optimise slightly here and there. No regressions detected in tests or benchmarks.