### PR TITLE
feat: Enable partial and full randomised states for WyHash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wyrand"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "A fast & portable non-cryptographic pseudorandom number generator and hashing algorithm"
@@ -22,6 +22,7 @@ rand_core = ["dep:rand_core"]
 serde1 = ["dep:serde"]
 wyhash = []
 randomised_wyhash = ["wyhash", "dep:getrandom"]
+fully_randomised_wyhash = ["randomised_wyhash"]
 v4_2 = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The crate will always export `WyRand` and will do so when set as `default-featur
 - **`hash`** - Enables `core::hash::Hash` implementation for `WyRand`.
 - **`wyhash`** - Enables `WyHash`, a fast & portable hashing algorithm. Based on the final v4 C implementation.
 - **`randomised_wyhash`** - Enables `RandomisedWyHashBuilder`, a means to source a randomised state for `WyHash` for use in collections like `HashMap`/`HashSet`. Enables `wyhash` feature if it is not already enabled.
+- **`fully_randomised_wyhash`** - Randomises not just the seed for `RandomisedWyHashBuilder`, but also the secret. Incurs a performance hit every time `WyHash` is initialised but it is more secure as a result. Enables `randomised_wyhash` if not already enabled.
 - **`v4_2`** - Switches the PRNG/Hashing algorithms to use the final v4.2 implementation.
 
 ## Building for WASM/Web

--- a/benches/rand_bench.rs
+++ b/benches/rand_bench.rs
@@ -66,6 +66,24 @@ fn wyhash_benchmark(c: &mut Criterion) {
                 },
             );
         });
+
+    c.bench_function("Hash new with default secret", |b| {
+        b.iter(|| WyHash::new_with_default_secret(black_box(42)));
+    });
+
+    c.bench_function("Hash new with random secret", |b| {
+        b.iter(|| WyHash::new(black_box(42), black_box(256)));
+    });
+
+    #[cfg(feature = "randomised_wyhash")]
+    c.bench_function("Random Hash new", |b| {
+        use wyrand::RandomWyHashState;
+        use std::hash::BuildHasher;
+
+        b.iter(|| {
+            RandomWyHashState::new().build_hasher()
+        });
+    });
 }
 
 pub fn benches() {


### PR DESCRIPTION
Adds a feature to enable full randomised state for `WyHash`, allowing for randomised seed AND secret, versus partial randomisation where only the seed is random and the default secret is used. This allows control over whether one wants to enable the more expensive but more secure option of initialising the entire state, or for partial randomisation in favour of speed.

The difference in perf between partial and full randomisation is 1.2 *nanoseconds* versus 228 *microseconds*. This is excluding the time it takes to source entropy from hardware sources.