### PR TITLE
Fix issues with using `WyHash` with `std::hash::Hash`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 .vscode
+.idea

--- a/benches/rand_bench.rs
+++ b/benches/rand_bench.rs
@@ -77,12 +77,10 @@ fn wyhash_benchmark(c: &mut Criterion) {
 
     #[cfg(feature = "randomised_wyhash")]
     c.bench_function("Random Hash new", |b| {
-        use wyrand::RandomWyHashState;
         use std::hash::BuildHasher;
+        use wyrand::RandomWyHashState;
 
-        b.iter(|| {
-            RandomWyHashState::new().build_hasher()
-        });
+        b.iter(|| RandomWyHashState::new().build_hasher());
     });
 }
 

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -142,14 +142,12 @@ impl WyHash {
 impl Hasher for WyHash {
     #[inline]
     fn write(&mut self, bytes: &[u8]) {
-        for chunk in bytes.chunks(u64::MAX as usize) {
-            let (lo, hi, seed) = self.consume_bytes(chunk);
+        let (lo, hi, seed) = self.consume_bytes(bytes);
 
-            self.lo = lo;
-            self.hi = hi;
-            self.seed = seed;
-            self.size += chunk.len() as u64;
-        }
+        self.lo = lo;
+        self.hi = hi;
+        self.seed = seed;
+        self.size += bytes.len() as u64;
     }
 
     #[inline]

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -195,57 +195,34 @@ mod tests {
     }
 
     #[cfg(not(feature = "v4_2"))]
-    #[test]
-    fn expected_final_v4_hasher_output() {
-        // Test cases generated from the C reference's test_vectors
-        #[rustfmt::skip]
-        let test_cases: [(u64, &str); 8] = [
-            (0x0409_638e_e2bd_e459, ""),
-            (0xa841_2d09_1b5f_e0a9, "a"),
-            (0x32dd_92e4_b291_5153, "abc"),
-            (0x8619_1240_89a3_a16b, "message digest"),
-            (0x7a43_afb6_1d7f_5f40, "abcdefghijklmnopqrstuvwxyz"),
-            (0xff42_329b_90e5_0d58, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"),
-            (0xc39c_ab13_b115_aad3, "12345678901234567890123456789012345678901234567890123456789012345678901234567890"),
-            (0xe44a_846b_fc65_00cd, "123456789012345678901234567890123456789012345678")
-        ];
-
-        test_cases
-            .into_iter()
-            .enumerate()
-            .map(|(seed, (expected, input))| {
-                let mut hasher = WyHash::new_with_secret(seed as u64, [WY0, WY1, WY2, WY3]);
-
-                hasher.write(input.as_bytes());
-
-                (input, expected, hasher.finish())
-            })
-            .for_each(|(input, expected_hash, computed_hash)| {
-                assert_eq!(
-                    expected_hash, computed_hash,
-                    "Hashed output didn't match expected for \"{}\"",
-                    input
-                );
-            });
-    }
+    #[rustfmt::skip]
+    const TEST_VECTORS: [(u64, &str); 8] = [
+        (0x0409_638e_e2bd_e459, ""),
+        (0xa841_2d09_1b5f_e0a9, "a"),
+        (0x32dd_92e4_b291_5153, "abc"),
+        (0x8619_1240_89a3_a16b, "message digest"),
+        (0x7a43_afb6_1d7f_5f40, "abcdefghijklmnopqrstuvwxyz"),
+        (0xff42_329b_90e5_0d58, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"),
+        (0xc39c_ab13_b115_aad3, "12345678901234567890123456789012345678901234567890123456789012345678901234567890"),
+        (0xe44a_846b_fc65_00cd, "123456789012345678901234567890123456789012345678"),
+    ];
 
     #[cfg(feature = "v4_2")]
-    #[test]
-    fn expected_final_v42_hasher_output() {
-        // Test cases generated from the C reference's test_vectors
-        #[rustfmt::skip]
-        let test_cases: [(u64, &str); 8] = [
-            (0x9322_8a4d_e0ee_c5a2, ""),
-            (0xc5ba_c3db_1787_13c4, "a"),
-            (0xa97f_2f7b_1d9b_3314, "abc"),
-            (0x786d_1f1d_f380_1df4, "message digest"),
-            (0xdca5_a813_8ad3_7c87, "abcdefghijklmnopqrstuvwxyz"),
-            (0xb9e7_34f1_17cf_af70, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"),
-            (0x6cc5_eab4_9a92_d617, "12345678901234567890123456789012345678901234567890123456789012345678901234567890"),
-            (0xe1d4_c58d_97ba_df5e, "123456789012345678901234567890123456789012345678")
-        ];
+    #[rustfmt::skip]
+    const TEST_VECTORS: [(u64, &str); 8] = [
+        (0x9322_8a4d_e0ee_c5a2, ""),
+        (0xc5ba_c3db_1787_13c4, "a"),
+        (0xa97f_2f7b_1d9b_3314, "abc"),
+        (0x786d_1f1d_f380_1df4, "message digest"),
+        (0xdca5_a813_8ad3_7c87, "abcdefghijklmnopqrstuvwxyz"),
+        (0xb9e7_34f1_17cf_af70, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"),
+        (0x6cc5_eab4_9a92_d617, "12345678901234567890123456789012345678901234567890123456789012345678901234567890"),
+        (0xe1d4_c58d_97ba_df5e, "123456789012345678901234567890123456789012345678"),
+    ];
 
-        test_cases
+    #[test]
+    fn expected_hasher_output() {
+        TEST_VECTORS
             .into_iter()
             .enumerate()
             .map(|(seed, (expected, input))| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@
 mod constants;
 #[cfg(feature = "wyhash")]
 mod hasher;
-mod wyrand;
 mod utils;
+mod wyrand;
 
 #[cfg(feature = "wyhash")]
 pub use hasher::*;


### PR DESCRIPTION
While `WyHash` works properly in the use case where a single call to `write` is followed by a call to `finish`, other use cases (such as those that would be caused by a `HashMap<(u32, u32), u32, RandomWyHashState>`) often cause some of the input data to be entirely ignored.

This modifies the `Hasher` implementation of `WyHash` such that it mixes in the `hi` and `lo` from previous calls to `write` and related functions using `wymix` before running it again. This keeps the property that `WyHash` generates the same output as the reference implementation when used with a single `write` call while making it both faster and more correct for use in a Rust `HashMap`.

Intended guarantees about the hash output:

```
/// # Stability
///
/// The result is only guaranteed to match the result `wyhash` would naturally produce if `write`
/// is called a single time, followed by a call to `finish`.
///
/// Any other sequence of events (including calls to `write_u32` or similar functions) are
/// guaranteed to have consistent results between platforms and versions of this crate, but may not
/// map well to the reference implementation.
```